### PR TITLE
fix: always invoke cb in aceAttribsToClasses (#4)

### DIFF
--- a/static/js/hooks.js
+++ b/static/js/hooks.js
@@ -11,6 +11,7 @@ exports.aceAttribsToClasses = (hookName, args, cb) => {
   if (args.key === 'specialCharacters' && args.value !== '') {
     return cb([`specialCharacters:${args.value}`]);
   }
+  return cb([]);
 };
 
 exports.aceCreateDomLine = (hookName, args, cb) => {

--- a/static/tests/backend/specs/hooks.js
+++ b/static/tests/backend/specs/hooks.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert').strict;
+const hooks = require('../../../../static/js/hooks');
+
+describe(__filename, function () {
+  describe('aceAttribsToClasses', function () {
+    it('invokes cb with the class when key matches and value is set', function (done) {
+      hooks.aceAttribsToClasses('aceAttribsToClasses', {key: 'specialCharacters', value: 'Ω'},
+          (classes) => {
+            assert.deepEqual(classes, ['specialCharacters:Ω']);
+            done();
+          });
+    });
+
+    it('invokes cb with an empty array when key does not match (regression for #4)', function (done) {
+      hooks.aceAttribsToClasses('aceAttribsToClasses', {key: 'bold', value: 'true'},
+          (classes) => {
+            assert.deepEqual(classes, []);
+            done();
+          });
+    });
+
+    it('invokes cb with an empty array when value is empty (regression for #4)', function (done) {
+      hooks.aceAttribsToClasses('aceAttribsToClasses', {key: 'specialCharacters', value: ''},
+          (classes) => {
+            assert.deepEqual(classes, []);
+            done();
+          });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the UNSETTLED FUNCTION BUG warning in the browser console for the \`aceAttribsToClasses\` hook (issue #4).
- The hook returned \`undefined\` without calling \`cb\` whenever the attribute key was not \`specialCharacters\` or its value was empty. Etherpad's hook framework logs a red warning about this because future async-capable hooks would freeze.
- Always invoke \`cb\` — with the special-character class array when the attribute matches, otherwise with an empty array.

## Test plan
- [x] New backend spec asserts cb is invoked in each of the three branches (match, non-match key, empty value).