### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 > uses a browser-side `require()` that Etherpad's current esbuild bundler
 > doesn't expose. Tracking fix in [#87](https://github.com/ether/ep_special_characters/issues/87).
 
-# ep_special_characters
-
+# Special Character Picker for Etherpad
 TODO: Describe the plugin.
 
 ## Installation


### PR DESCRIPTION
Replace the placeholder `ep_special_characters` heading in README.md with "Special Character Picker for Etherpad".